### PR TITLE
Poldvillanueva/boardresponsiveness

### DIFF
--- a/src/components/about/BoardCard.tsx
+++ b/src/components/about/BoardCard.tsx
@@ -9,8 +9,10 @@ type BoardCardProps = {
 
 const BoardCard = ({ position, name, webp, is_apprentice }: BoardCardProps) => {
   return (
-    <div className="flex scale-170 flex-col items-center overflow-hidden rounded-xl p-6">
-      <div className="relative h-64 w-48">
+    <div className="flex flex-col items-center overflow-hidden rounded-xl p-6">
+      <div
+        className="relative h-56 w-40 sm:h-64 sm:w-48 md:h-72 md:w-52 lg:h-80 lg:w-56 xl:h-96 xl:w-64 transition-all duration-300"
+      >
         <div
           className="absolute z-0 h-full w-full -translate-y-1 translate-x-2"
           style={{ backgroundColor: "#9ab4d6" }}
@@ -36,11 +38,15 @@ const BoardCard = ({ position, name, webp, is_apprentice }: BoardCardProps) => {
               : "linear-gradient(to right, rgba(30, 64, 175, 0.8) 80%, rgba(30, 64, 175, 0.2) 100%)",
           }}
         >
-          <span className="font-inria-serif text-xs">{position}</span>
+          <span className="font-inria-serif text-xs sm:text-sm md:text-base lg:text-lg xl:text-xl">
+            {position}
+          </span>
         </div>
       </div>
 
-      <p className="font-inria-serif mt-1 text-xl text-gray-800">{name}</p>
+      <p className="font-inria-serif mt-2 text-lg sm:text-xl md:text-2xl lg:text-3xl text-gray-800">
+        {name}
+      </p>
     </div>
   );
 };

--- a/src/components/about/BoardCard.tsx
+++ b/src/components/about/BoardCard.tsx
@@ -10,9 +10,7 @@ type BoardCardProps = {
 const BoardCard = ({ position, name, webp, is_apprentice }: BoardCardProps) => {
   return (
     <div className="flex flex-col items-center overflow-hidden rounded-xl p-6">
-      <div
-        className="relative h-56 w-40 sm:h-64 sm:w-48 md:h-72 md:w-52 lg:h-80 lg:w-56 xl:h-96 xl:w-64 transition-all duration-300"
-      >
+      <div className="relative h-56 w-40 transition-all duration-300 sm:h-64 sm:w-48 md:h-72 md:w-52 lg:h-80 lg:w-56 xl:h-96 xl:w-64">
         <div
           className="absolute z-0 h-full w-full -translate-y-1 translate-x-2"
           style={{ backgroundColor: "#9ab4d6" }}
@@ -44,7 +42,7 @@ const BoardCard = ({ position, name, webp, is_apprentice }: BoardCardProps) => {
         </div>
       </div>
 
-      <p className="font-inria-serif mt-2 text-lg sm:text-xl md:text-2xl lg:text-3xl text-gray-800">
+      <p className="font-inria-serif mt-2 text-lg text-gray-800 sm:text-xl md:text-2xl lg:text-3xl">
         {name}
       </p>
     </div>

--- a/src/components/about/BoardGrid.tsx
+++ b/src/components/about/BoardGrid.tsx
@@ -8,7 +8,7 @@ const BoardGrid = () => {
   const apprentices = cabData.filter((member) => member.is_apprentice);
 
   return (
-    <div className="relative flex w-full overflow-x-hidden overflow-y-hidden px-6 py-16">
+    <div className="relative flex w-full overflow-x-hidden overflow-y-hidden px-6 py-6">
       <div className="absolute top-0 -left-50 z-0 -translate-x-1 scale-125 rotate-[270deg]">
         <Image
           src="/floral/blackflower.webp"
@@ -28,7 +28,7 @@ const BoardGrid = () => {
 
       <div className="w-full flex-col">
         <div className="relative mb-10">
-          <div className="mt-20 grid grid-cols-1 place-items-center gap-y-6 md:grid-cols-2 md:gap-x-0 lg:grid-cols-3 lg:gap-x-0 lg:gap-y-50">
+          <div className="mt-20 grid grid-cols-1 place-items-center gap-y-6 md:grid-cols-2 md:gap-x-0 lg:grid-cols-3 lg:gap-x-0 lg:gap-y-20">
             {cabinetMembers.map((member, index) => (
               <BoardCard
                 key={index}


### PR DESCRIPTION
Added Responsiveness to the Board Grid for the sm-xl breakpoints 
<img width="1509" alt="Screenshot 2025-05-19 at 8 27 03 PM" src="https://github.com/user-attachments/assets/1ddfa6ca-2b1d-45d0-9e3a-72df843e24b6" />
<img width="1251" alt="Screenshot 2025-05-19 at 8 27 19 PM" src="https://github.com/user-attachments/assets/5b57d759-d1c7-46fa-a36f-70a1425fdd89" />
<img width="999" alt="Screenshot 2025-05-19 at 8 27 59 PM" src="https://github.com/user-attachments/assets/28066dea-8dac-455b-ab52-10d34575a9e0" />
<img width="497" alt="Screenshot 2025-05-19 at 8 29 36 PM" src="https://github.com/user-attachments/assets/327e2c08-20cc-46df-9b17-3297ced7ae63" />
